### PR TITLE
Fix ユーザー削除及びチーム編集機能修正

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -28,6 +28,8 @@ class AssignsController < ApplicationController
   def assign_destroy(assign, assigned_user)
     if assigned_user == assign.team.owner
       I18n.t('views.messages.cannot_delete_the_leader')
+    elsif (Assign.where(user_id: assigned_user.id) != current_user.id) && ( assign.team.owner.id != current_user.id )
+    '自分がオーナーであるチームのユーザー、若しくはユーザー本人でないと削除はできません。'
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
     elsif assign.destroy
@@ -37,11 +39,11 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_member_4_some_reason')
     end
   end
-  
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :correct_user_is_owner?, only:[:edit, :update]
 
   def index
     @teams = Team.all
@@ -47,7 +48,19 @@ class TeamsController < ApplicationController
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
   end
 
+  def isOwned?(user)
+    return false if user.nil?
+    return self.user_id == user.id
+  end
+
   private
+
+  def correct_user_is_owner?
+    if @team.owner.id != current_user.id
+      redirect_to team_url
+      flash[:notice] = "オーナー以外に編集権限はありません"
+    end
+  end
 
   def set_team
     @team = Team.friendly.find(params[:id])


### PR DESCRIPTION
- [ ] Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること

- [ ]TeamのeditはTeamのリーダー（オーナー）のみができるようにすること
 